### PR TITLE
Fix font links

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,7 +896,7 @@
       <div class="centered-col">
 		  <p>Website & testing by <a href="https://arrowtype.com">Arrow Type</a></p>
 		  <p>Test source: <a href="https://github.com/arrowtype/vf-slnt-test">github.com/arrowtype/vf-slnt-test</a></p>
-        <p class="colophon">Fonts: <a href="github.com/rsms/inter">Inter</a> & <a href="github.com/arrowtype/recursive">Recursive</a></p>
+        <p class="colophon">Fonts: <a href="https://github.com/rsms/inter">Inter</a> & <a href="https://github.com/arrowtype/recursive">Recursive</a></p>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
The links for fonts weren't working, GitHub thought it was linking to a file in the repo.